### PR TITLE
Create new contextmenu action

### DIFF
--- a/default.py
+++ b/default.py
@@ -5,6 +5,7 @@
 from resources.lib.helper import *
 from resources.lib.editor import *
 from resources.lib.rating_updater import *
+from context import *
 
 ########################
 
@@ -63,6 +64,9 @@ class Main:
                 winprop('updatenfo.bool', True)
                 update_nfo(dbid=self.dbid, dbtype=self.dbtype, forced=True)
                 winprop('updatenfo', clear=True)
+
+            elif self.action == 'contextmenu':
+                ContextMenu(dbid=self.dbid, dbtype=self.dbtype)
 
             else:
                 self._editor()


### PR DESCRIPTION
Hi Sualfred,

I have modified your Embuary skin to have an entry for your Metadata Editor addon in the video info dialog 'More ...' context menu, but prefer to have only one menu item that opens up the main dialog of the Metadata Editor, rather than the individual functions provided by the addon.

I have therefore added a new contextmenu action to allow the main dialog to be opened programmatically using RunScript(script.metadata.editor,action=contextmenu) or similar, rather than only via the actual context menu.

For your consideration.