### PR TITLE
Update helper.py - xbmc.translatePath is deprecated

### DIFF
--- a/resources/lib/helper.py
+++ b/resources/lib/helper.py
@@ -24,7 +24,7 @@ from contextlib import contextmanager
 
 ADDON = xbmcaddon.Addon()
 ADDON_ID = ADDON.getAddonInfo('id')
-ADDON_DATA_PATH = os.path.join(xbmc.translatePath("special://profile/addon_data/%s" % ADDON_ID))
+ADDON_DATA_PATH = os.path.join(xbmcvfs.translatePath("special://profile/addon_data/%s" % ADDON_ID))
 
 NOTICE = xbmc.LOGINFO
 WARNING = xbmc.LOGWARNING


### PR DESCRIPTION
xbmc.translatePath is deprecated and might be removed in future kodi versions. Changed to xbmcvfs.translatePath instead.