### PR TITLE
Update helper.py

### DIFF
--- a/resources/lib/helper.py
+++ b/resources/lib/helper.py
@@ -24,7 +24,7 @@ from contextlib import contextmanager
 
 ADDON = xbmcaddon.Addon()
 ADDON_ID = ADDON.getAddonInfo('id')
-ADDON_DATA_PATH = os.path.join(xbmc.translatePath("special://profile/addon_data/%s" % ADDON_ID))
+ADDON_DATA_PATH = os.path.join(xbmcvfs.translatePath("special://profile/addon_data/%s" % ADDON_ID))
 
 NOTICE = xbmc.LOGINFO
 WARNING = xbmc.LOGWARNING


### PR DESCRIPTION
After installing the add-on script Metadata Editor version 3.0.1 from the Kodi.tv repo v20. 
The error message that: module 'xmbc' has no attribute 'translate Path'. and that if ignored it may lead to memory leaks. 

In Python API v20 :
{ translatePath, "", xbmc.translatePath() function was removed completely. Use xbmcvfs.translatePath(). 

After making this change no longer receiving error messages.